### PR TITLE
Fix link errors

### DIFF
--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -10,7 +10,7 @@
 # Add your declarations here
 
 SEABREEZE=$(TOP)
-EPICS_BASE=/usr/lib/epics
+EPICS_BASE=/home/wuestenf/EPICS/EPICS-7.0.8/base-7.0.8
 
 # These lines allow developers to override these RELEASE settings
 # without having to modify this file directly.

--- a/seabreezeApp/src/Makefile
+++ b/seabreezeApp/src/Makefile
@@ -5,6 +5,7 @@ include $(TOP)/configure/CONFIG
 
 LIBRARY_IOC = seabreeze
 
+USR_CXXFLAGS += -std=c++11
 
 INC += api/DeviceFactory.h
 INC += api/DllDecl.h
@@ -738,7 +739,9 @@ LIB_SRCS += WriteEEPROMSlotExchange.cpp
 LIB_SRCS += WriteTECQESetPointExchange.cpp
 LIB_SRCS += WriteTECSetPointExchange.cpp
 
-
+LIB_SRCS += NativeUSBLinux.cpp
+LIB_SRCS += NativeRS232POSIX.c
+LIB_SRCS += NativeSystemPOSIX.c
 
 #=============================
 

--- a/seabreezeApp/src/Makefile
+++ b/seabreezeApp/src/Makefile
@@ -739,7 +739,9 @@ LIB_SRCS += WriteEEPROMSlotExchange.cpp
 LIB_SRCS += WriteTECQESetPointExchange.cpp
 LIB_SRCS += WriteTECSetPointExchange.cpp
 
-LIB_SRCS += NativeUSBLinux.cpp
+ifeq (linux, $(findstring linux, $(T_A)))
+LIB_SRCS += NativeUSBLinux.c
+endif
 LIB_SRCS += NativeRS232POSIX.c
 LIB_SRCS += NativeSystemPOSIX.c
 


### PR DESCRIPTION
This pull request fixes the link errors that occur when linking the library with an IOC code.
To do that it adds three files that where missing in the LIB_SRS list. One of them is safeguarded by an ifeq statement to only be compiled on Linux systems.

In addition it adds a CPP flag that forces the compiler to stich to the C++11 standard as newer standards do not support dynamic exception casting.